### PR TITLE
Preserve Albums and Genres Data

### DIFF
--- a/album_genre_input.rb
+++ b/album_genre_input.rb
@@ -7,9 +7,8 @@ module HandleAlbumAndGenreInput
 
   def list_all_albums
     puts 'No music album has been added yet! Please, add one' if @albums.empty?
-
     @albums.each_with_index do |album, index|
-      puts "#{index + 1}) Album was published in #{album.publish_date[:year]} "\
+      puts "#{index + 1}) #{album.name} album was published on #{album.publish_date[:year]}-#{album.publish_date[:month]}-#{album.publish_date[:day]} "\
            " | On Spotify: #{album.on_spotify} | Archivable : #{album.can_be_archived?} "
     end
   end
@@ -23,6 +22,8 @@ module HandleAlbumAndGenreInput
   end
 
   def add_music_album
+    puts 'Please, type the album name: '
+    name =  gets.chomp
     album_day = validate_day('Please, enter the day the album was published (1-31)')
     album_month = validate_month('Please, enter the month the album was published (1-12)')
     album_year = validate_year('Please, enter the year the album was published')
@@ -30,7 +31,7 @@ module HandleAlbumAndGenreInput
 
     spotify = validate_spotify_status('Is this album on spotify?(y/n)')
 
-    @albums << MusicAlbum.new(date_of_publish, spotify)
+    @albums << MusicAlbum.new(name, date_of_publish, spotify)
     puts 'Album has been successfully created'
   end
 

--- a/album_genre_input.rb
+++ b/album_genre_input.rb
@@ -8,7 +8,8 @@ module HandleAlbumAndGenreInput
   def list_all_albums
     puts 'No music album has been added yet! Please, add one' if @albums.empty?
     @albums.each_with_index do |album, index|
-      puts "#{index + 1}) #{album.name} album was published on #{album.publish_date[:year]}-#{album.publish_date[:month]}-#{album.publish_date[:day]} "\
+      puts "#{index + 1}) #{album.name} album was published on #{album.publish_date[:year]}-"\
+           "#{album.publish_date[:month]}-#{album.publish_date[:day]} "\
            " | On Spotify: #{album.on_spotify} | Archivable : #{album.can_be_archived?} "
     end
   end
@@ -23,7 +24,7 @@ module HandleAlbumAndGenreInput
 
   def add_music_album
     puts 'Please, type the album name: '
-    name =  gets.chomp
+    name = gets.chomp
     album_day = validate_day('Please, enter the day the album was published (1-31)')
     album_month = validate_month('Please, enter the month the album was published (1-12)')
     album_year = validate_year('Please, enter the year the album was published')

--- a/local/music_album.json
+++ b/local/music_album.json
@@ -1,1 +1,0 @@
-[{"publish_date":{"day":1,"month":11,"year":2020},"on_spotify":true}]

--- a/local/music_album.json
+++ b/local/music_album.json
@@ -1,0 +1,1 @@
+[{"publish_date":{"day":1,"month":11,"year":2020},"on_spotify":true}]

--- a/main.rb
+++ b/main.rb
@@ -21,6 +21,7 @@ class App
     read_json_books if File.exist?('./local/books.json')
     read_json_labels if File.exist?('./local/labels.json')
     read_json_musicalbum if File.exist?('./local/music_album.json')
+    read_json_genre if File.exist?('./local/genre.json')
   end
 
   def run

--- a/main.rb
+++ b/main.rb
@@ -20,6 +20,7 @@ class App
     @genres = []
     read_json_books if File.exist?('./local/books.json')
     read_json_labels if File.exist?('./local/labels.json')
+    read_json_musicalbum if File.exist?('./local/music_album.json')
   end
 
   def run

--- a/music_album.rb
+++ b/music_album.rb
@@ -1,11 +1,12 @@
 require_relative 'item'
 
 class MusicAlbum < Item
-  attr_accessor :on_spotify, :archived
+  attr_accessor :on_spotify, :archived, :name
   attr_reader :publish_date
 
-  def initialize(publish_date, on_spotify)
+  def initialize(name, publish_date, on_spotify)
     super(publish_date)
+    @name = name
     @on_spotify = on_spotify
   end
 

--- a/spec/genre_spec.rb
+++ b/spec/genre_spec.rb
@@ -3,7 +3,7 @@ require_relative 'spec_helper'
 describe Genre do
   before :each do
     @genre = Genre.new('Pop')
-    @album = MusicAlbum.new({ day: 31, month: 5, year: 2010 }, true)
+    @album = MusicAlbum.new('King Of Pop', { day: 31, month: 5, year: 2010 }, true)
   end
 
   it 'checks if genre is an instance of Genre class' do
@@ -24,7 +24,7 @@ describe Genre do
   end
 
   it 'confirms there are two items in the array' do
-    @album2 = @album = MusicAlbum.new({ day: 12, month: 5, year: 1997 }, false)
+    @album2 = @album = MusicAlbum.new('Made in Lagos', { day: 12, month: 5, year: 1997 }, false)
     @genre.add_item(@album)
     @genre.add_item(@album2)
     expect(@genre.items).to match_array([@album, @album2])

--- a/spec/music_album_spec.rb
+++ b/spec/music_album_spec.rb
@@ -2,8 +2,8 @@ require_relative 'spec_helper'
 
 describe MusicAlbum do
   before :each do
-    @album1 = MusicAlbum.new({ day: 17, month: 10, year: 1988 }, false)
-    @album2 = MusicAlbum.new({ day: 31, month: 5, year: 2010 }, true)
+    @album1 = MusicAlbum.new('Apollo', { day: 17, month: 10, year: 1988 }, false)
+    @album2 = MusicAlbum.new('Thriller', { day: 31, month: 5, year: 2010 }, true)
   end
 
   it 'checks if album_1 is an instance of the MusicAlbum class' do
@@ -16,6 +16,14 @@ describe MusicAlbum do
 
   it 'confirms album_3 is not an instance of the MusicAlbum class' do
     expect(@album3).not_to be_an_instance_of MusicAlbum
+  end
+
+  it 'checks if album_1 name is Apollo' do
+    expect(@album1.name).to eq "Apollo"
+  end
+
+  it 'checks if album_2 name is not Carpe Diem' do
+    expect(@album2.name).not_to be "Carpe Diem"
   end
 
   it 'checks if album1 can be archived' do

--- a/spec/music_album_spec.rb
+++ b/spec/music_album_spec.rb
@@ -19,11 +19,11 @@ describe MusicAlbum do
   end
 
   it 'checks if album_1 name is Apollo' do
-    expect(@album1.name).to eq "Apollo"
+    expect(@album1.name).to eq 'Apollo'
   end
 
   it 'checks if album_2 name is not Carpe Diem' do
-    expect(@album2.name).not_to be "Carpe Diem"
+    expect(@album2.name).not_to be 'Carpe Diem'
   end
 
   it 'checks if album1 can be archived' do

--- a/storage.rb
+++ b/storage.rb
@@ -24,7 +24,7 @@ module Storage
 
     JSON.parse(File.read(file)).each do |album|
       date = { day: album['publish_date']['day'], month: album['publish_date']['month'],
-        year: album['publish_date']['year'] }
+               year: album['publish_date']['year'] }
       @albums << MusicAlbum.new(album['name'], date, album['on_spotify'])
     end
   end

--- a/storage.rb
+++ b/storage.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Metrics
 
 require_relative 'music_album'
+require_relative 'genre'
 module Storage
   def read_json_books
     books_json = File.read('./local/books.json')
@@ -24,7 +25,15 @@ module Storage
     JSON.parse(File.read(file)).each do |album|
       date = { day: album['publish_date']['day'], month: album['publish_date']['month'],
         year: album['publish_date']['year'] }
-      @albums << MusicAlbum.new(date, album['on_spotify'])
+      @albums << MusicAlbum.new(album['name'], date, album['on_spotify'])
+    end
+  end
+
+  def read_json_genre
+    file = './local/genre.json'
+
+    JSON.parse(File.read(file)).each do |genre|
+      @genres << Genre.new(genre['name'])
     end
   end
 
@@ -32,9 +41,11 @@ module Storage
     File.new('./local/books.json', 'a') unless File.exist?('./local/books.json') || @books.empty?
     File.new('./local/labels.json', 'a') unless File.exist?('./local/labels.json') || @labels.empty?
     File.new('./local/music_album.json', 'a') unless File.exist?('./local/music_album.json') || @albums.empty?
+    File.new('./local/genre.json', 'a') unless File.exist?('./local/genre.json') || @genres.empty?
     bks = []
     lbs = []
     music_album = []
+    genre_arr = []
     @labels.each do |label|
       h = { title: label.title, color: label.color }
       lbs.push(h)
@@ -46,13 +57,19 @@ module Storage
     end
 
     @albums.each do |album|
-      album_hash = { publish_date: album.publish_date, on_spotify: album.on_spotify }
+      album_hash = { name: album.name, publish_date: album.publish_date, on_spotify: album.on_spotify }
       music_album.push(album_hash)
+    end
+
+    @genres.each do |genre|
+      genre_hash = { name: genre.name }
+      genre_arr.push(genre_hash)
     end
 
     File.write('./local/books.json', JSON.dump(bks)) unless @books.empty?
     File.write('./local/labels.json', JSON.dump(lbs)) unless @labels.empty?
-    File.write('./local/music_album.json', JSON.dump(music_album)) unless @albums.empty?
+    File.write('./local/music_album.json', JSON.generate(music_album)) unless @albums.empty?
+    File.write('./local/genre.json', JSON.generate(genre_arr)) unless @genres.empty?
   end
 end
 

--- a/storage.rb
+++ b/storage.rb
@@ -1,4 +1,6 @@
 # rubocop:disable Metrics
+
+require_relative 'music_album'
 module Storage
   def read_json_books
     books_json = File.read('./local/books.json')
@@ -16,21 +18,41 @@ module Storage
     data_labels.each { |label| create_label(label['title'], label['color']) }
   end
 
+  def read_json_musicalbum
+    file = './local/music_album.json'
+
+    JSON.parse(File.read(file)).each do |album|
+      date = { day: album['publish_date']['day'], month: album['publish_date']['month'],
+        year: album['publish_date']['year'] }
+      @albums << MusicAlbum.new(date, album['on_spotify'])
+    end
+  end
+
   def save_json
     File.new('./local/books.json', 'a') unless File.exist?('./local/books.json') || @books.empty?
     File.new('./local/labels.json', 'a') unless File.exist?('./local/labels.json') || @labels.empty?
+    File.new('./local/music_album.json', 'a') unless File.exist?('./local/music_album.json') || @albums.empty?
     bks = []
     lbs = []
+    music_album = []
     @labels.each do |label|
       h = { title: label.title, color: label.color }
       lbs.push(h)
     end
+
     @books.each do |book|
       h = { publish_date: book.publish_date, publisher: book.publisher, cover_state: book.cover_state }
       bks.push(h)
     end
+
+    @albums.each do |album|
+      album_hash = { publish_date: album.publish_date, on_spotify: album.on_spotify }
+      music_album.push(album_hash)
+    end
+
     File.write('./local/books.json', JSON.dump(bks)) unless @books.empty?
     File.write('./local/labels.json', JSON.dump(lbs)) unless @labels.empty?
+    File.write('./local/music_album.json', JSON.dump(music_album)) unless @albums.empty?
   end
 end
 


### PR DESCRIPTION
## In this milestone, I completed the following requirement;

- All data from the `Genre` and `MusicAlbum` classes should be preserved by saving collections in `.json` files.

- Available `json` files for musicalbum and genre classes are;
    - `music_album.json`, and
    - `genre.json`
    
- I also added the `name` argument to  the MusicAlbum class and updated its unit tests to contain the new `name` argument.

Closes #14 