### PR TITLE
Catalog - Bug fix (Label and book relationship)

### DIFF
--- a/handle_input_1.rb
+++ b/handle_input_1.rb
@@ -98,6 +98,7 @@ module HandleInput1
           run
         else
           @labels[ind2].add_item(@books[ind])
+          @labels.each_with_index {|label, index| label.items.include? @books[ind] && index != ind2 ? label.items.delete(@books[ind]) : nil}
           puts "Label #{@labels[ind2].title} assigned to the book published by #{@books[ind].publisher}"
           enter
         end

--- a/handle_input_1.rb
+++ b/handle_input_1.rb
@@ -98,7 +98,9 @@ module HandleInput1
           run
         else
           @labels[ind2].add_item(@books[ind])
-          @labels.each_with_index {|label, index| label.items.include? @books[ind] && index != ind2 ? label.items.delete(@books[ind]) : nil}
+          @labels.each_with_index do |label, index|
+            (label.items.include? @books[ind]) && (index != ind2) ? label.items.delete(@books[ind]) : nil
+          end
           puts "Label #{@labels[ind2].title} assigned to the book published by #{@books[ind].publisher}"
           enter
         end


### PR DESCRIPTION
# Changes 
### Fixed an issue where the `1 to many` relationship between label and book was not respected.

### Before:
  - User could assign a book to a label.
  - The same book could be assigned to another label.
  - Both labels would have the book in their items array.

### Now:
  - User can assign a book to a label.
  - If the same book is assigned to another label, it gets deleted from each other label that contains it.